### PR TITLE
Fix: Marks of other projects are showing up in another project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 All notable changes to the "markem" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
-- Initial release
+- More than one mark for the same file
+- Map files to num keys based on the order eg. Ctrl + Alt + (1/2/3) etc
+
+## [0.0.3] - 2025-08-03
+
+### Fixed
+
+- Marks of other projects are showing up in another project (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the "markem" extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markem",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markem",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "devDependencies": {
         "@types/lodash": "^4.17.20",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/tam2628/markem"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.102.0"
   },

--- a/src/vscodestore.ts
+++ b/src/vscodestore.ts
@@ -6,28 +6,28 @@ const MARK_FILE_KEY = 'marks';
 const CURRENT_OPEN_FILE_POSITION_KEY = 'currentOpenFilePosition';
 
 export function readMarks(context: vscode.ExtensionContext): Mark[] {
-    return context.globalState.get<Mark[]>('marks', []);
+    return context.workspaceState.get<Mark[]>('marks', []);
 }
 
 export function writeMark(context: vscode.ExtensionContext, mark: Mark): Thenable<void> {
     const existingMarks = readMarks(context);
     const updatedMarks = performDiff(existingMarks, mark);
-    return context.globalState.update(MARK_FILE_KEY, updatedMarks);        
+    return context.workspaceState.update(MARK_FILE_KEY, updatedMarks);
 }
 
 export function writeMarks(context: vscode.ExtensionContext, mark: Mark[]): Thenable<void> {
-    return context.globalState.update(MARK_FILE_KEY, mark);
+    return context.workspaceState.update(MARK_FILE_KEY, mark);
 }
 
 export async function clearMarks(context: vscode.ExtensionContext): Promise<void> {
-    await context.globalState.update(MARK_FILE_KEY, []);
+    await context.workspaceState.update(MARK_FILE_KEY, []);
     await writeCurrentOpenFilePosition(context, -1);
 }
 
 export function readCurrentOpenFilePosition(context: vscode.ExtensionContext): number {
-    return context.globalState.get<number>(CURRENT_OPEN_FILE_POSITION_KEY, -1);
+    return context.workspaceState.get<number>(CURRENT_OPEN_FILE_POSITION_KEY, -1);
 }
 
 export function writeCurrentOpenFilePosition(context: vscode.ExtensionContext, position: number): Thenable<void> {
-    return context.globalState.update(CURRENT_OPEN_FILE_POSITION_KEY, position);
+    return context.workspaceState.update(CURRENT_OPEN_FILE_POSITION_KEY, position);
 }


### PR DESCRIPTION
Using workspace state, instead of global state